### PR TITLE
Adiciona funcionalidade para desinscrever participantes de atividades

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -120,3 +120,27 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Validate email format
+    if not EMAIL_REGEX.match(email):
+        raise HTTPException(status_code=400, detail="Invalid email format")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(
+            status_code=400, detail="Student is not signed up for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -13,6 +13,9 @@ document.addEventListener("DOMContentLoaded", () => {
       // Clear loading message
       activitiesList.innerHTML = "";
 
+      // Clear existing options in the select dropdown (keep the default option)
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
+
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
@@ -25,7 +28,21 @@ document.addEventListener("DOMContentLoaded", () => {
         if (details.participants.length > 0) {
           const participantsList = details.participants.map(email => {
             const li = document.createElement("li");
-            li.textContent = email;
+            li.className = "participant-item";
+
+            const emailSpan = document.createElement("span");
+            emailSpan.className = "participant-email";
+            emailSpan.textContent = email;
+
+            const deleteBtn = document.createElement("button");
+            deleteBtn.className = "delete-btn";
+            deleteBtn.innerHTML = "🗑️";
+            deleteBtn.title = `Remove ${email}`;
+            deleteBtn.onclick = () => unregisterParticipant(name, email);
+
+            li.appendChild(emailSpan);
+            li.appendChild(deleteBtn);
+
             return li.outerHTML;
           }).join("");
 
@@ -89,6 +106,8 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // Refresh the activities list to show updated participant count
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -107,6 +126,46 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Error signing up:", error);
     }
   });
+
+  // Function to unregister a participant
+  async function unregisterParticipant(activityName, email) {
+    if (!confirm(`Are you sure you want to remove ${email} from ${activityName}?`)) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activityName)}/signup?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        // Refresh the activities list to show updated participant count
+        fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+
+      // Hide message after 5 seconds
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering participant:", error);
+    }
+  }
 
   // Initialize app
   fetchActivities();

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -158,11 +158,44 @@ footer {
 }
 
 .participants-list {
-  list-style-type: disc;
-  margin-left: 20px;
+  list-style-type: none;
+  margin-left: 0;
   margin-bottom: 0;
   color: #333;
   font-size: 15px;
+}
+
+.participant-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.participant-item:last-child {
+  border-bottom: none;
+}
+
+.participant-email {
+  flex: 1;
+}
+
+.delete-btn {
+  background: none;
+  border: none;
+  color: #d32f2f;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  transition: background-color 0.2s, color 0.2s;
+  margin-left: 10px;
+}
+
+.delete-btn:hover {
+  background-color: #ffebee;
+  color: #b71c1c;
 }
 
 .no-participants {


### PR DESCRIPTION
This pull request introduces functionality to allow users to unregister from activities, enhances the user interface for managing participants, and updates the styling for better user experience. The most significant changes include adding a new endpoint for unregistering participants, updating the frontend to support participant removal, and improving the styling of participant lists.

### Backend Changes:
* Added a new `unregister_from_activity` endpoint in `src/app.py` to allow users to remove themselves from an activity. This includes validation for activity existence, email format, and participant enrollment.

### Frontend Changes:
* Updated `src/static/app.js` to include a function (`unregisterParticipant`) for removing participants from activities. This integrates with the backend endpoint and refreshes the activity list after updates.
* Enhanced the participant list rendering in `src/static/app.js` by adding delete buttons next to each participant. These buttons trigger the `unregisterParticipant` function.
* Ensured the activity dropdown is cleared and refreshed when activities are loaded.
* Added a call to `fetchActivities` after successful signups to update the participant count dynamically.

### Styling Changes:
* Updated `src/static/styles.css` to improve the appearance of participant lists by removing bullet points, adding spacing, and styling the delete buttons with hover effects